### PR TITLE
Bugfix/fix config json file not being copied in library

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -23,7 +23,7 @@
  */
 
 group = "de.trustedshops.gradle.trustbadge"
-version = "0.0.01"
+version = "0.0.02"
 
 plugins {
     `java-gradle-plugin`

--- a/src/main/kotlin/de/trustedshops/gradle/trustbadge/config/ProduceConfigPlugin.kt
+++ b/src/main/kotlin/de/trustedshops/gradle/trustbadge/config/ProduceConfigPlugin.kt
@@ -59,6 +59,7 @@ class ProduceConfigPlugin: Plugin<Project> {
 
 internal fun File.copyToTargetIfNotIdentical(target: File): Boolean {
     return if (!this.readText().contentEquals(target.readText())) {
+        if (!target.exists()) { target.createNewFile() }
         this.copyTo(target, overwrite = true)
         true
     } else { false }


### PR DESCRIPTION
Relates OR Closes #0000

## Description
The `copyTo()` function used inside. `File.copyToTargetIfNotIdentical(...)` does not create a new target file if it does not exists. Therefore, the file is created manually if it does not exist.
