### PR TITLE
Bugfix/fix config json file not being copied inside library

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -23,7 +23,7 @@
  */
 
 group = "de.trustedshops.gradle.trustbadge"
-version = "0.0.02"
+version = "0.0.03"
 
 plugins {
     `java-gradle-plugin`

--- a/src/main/kotlin/de/trustedshops/gradle/trustbadge/config/ProduceConfigPlugin.kt
+++ b/src/main/kotlin/de/trustedshops/gradle/trustbadge/config/ProduceConfigPlugin.kt
@@ -57,12 +57,25 @@ class ProduceConfigPlugin: Plugin<Project> {
     }
 }
 
+/**
+ * Copies content of this file to [target] if it is different.
+ *
+ * @returns true if the file was created/overwritten, or false if the target was not different.
+ */
 internal fun File.copyToTargetIfNotIdentical(target: File): Boolean {
-    return if (!this.readText().contentEquals(target.readText())) {
-        if (!target.exists()) { target.createNewFile() }
+    return if (target.exists()) {
+        if (this.readText().contentEquals(target.readText())) {
+            false
+        }
+        else {
+            this.copyTo(target, overwrite = true)
+            true
+        }
+    } else {
+        target.createNewFile()
         this.copyTo(target, overwrite = true)
         true
-    } else { false }
+    }
 }
 
 internal fun decodeJsonAndProduceConfigFile(

--- a/src/test/kotlin/de/trustedshops/gradle/trustbadge/config/ProduceConfigPluginTest.kt
+++ b/src/test/kotlin/de/trustedshops/gradle/trustbadge/config/ProduceConfigPluginTest.kt
@@ -126,4 +126,24 @@ class ProduceConfigPluginTest {
         // assert
         assertFalse(isNewFileCreated)
     }
+
+    @Test fun `copy file to target creates new file if target does not exist`() {
+
+        // arrange
+        val sourceContent = "Cologne"
+
+        val sourceFile = File(projectDir.path, "fakeSource.md").apply {
+            createNewFile()
+            writeText(sourceContent)
+        }
+        val targetFile = File(projectDir.path, "fakeTarget.md")
+        println(sourceFile.readText())
+
+        // act
+        val isNewFileCreated = sourceFile.copyToTargetIfNotIdentical(targetFile)
+
+        // assert
+        assertTrue(targetFile.exists())
+        assertTrue(isNewFileCreated)
+    }
  }


### PR DESCRIPTION
<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

## Description
- fix copyTo() function not creating a new target file if it is missing.
- update unit tests
